### PR TITLE
feat: add option to require currency pairs to be pre-authorized before initialization

### DIFF
--- a/lib/Context.sol
+++ b/lib/Context.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _contextSuffixLength() internal view virtual returns (uint256) {
+        return 0;
+    }
+}

--- a/lib/Ownable.sol
+++ b/lib/Ownable.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)
+
+pragma solidity ^0.8.20;
+
+import {Context} from "./Context.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * The initial owner is set to the address provided by the deployer. This can
+ * later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    /**
+     * @dev The caller account is not authorized to perform an operation.
+     */
+    error OwnableUnauthorizedAccount(address account);
+
+    /**
+     * @dev The owner is not a valid owner account. (eg. `address(0)`)
+     */
+    error OwnableInvalidOwner(address owner);
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(initialOwner);
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if the sender is not the owner.
+     */
+    function _checkOwner() internal view virtual {
+        if (owner() != _msgSender()) {
+            revert OwnableUnauthorizedAccount(_msgSender());
+        }
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby disabling any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        if (newOwner == address(0)) {
+            revert OwnableInvalidOwner(address(0));
+        }
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}

--- a/script/AstriaOracle.s.sol
+++ b/script/AstriaOracle.s.sol
@@ -9,7 +9,7 @@ contract AstriaOracleScript is Script {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
         address oracleSenderAddress = vm.envAddress("EVM_ORACLE_SENDER_ADDRESS");
-        new AstriaOracle(oracleSenderAddress);
+        new AstriaOracle(oracleSenderAddress, false);
 
         vm.stopBroadcast();
     }
@@ -22,6 +22,7 @@ contract AstriaOracleScript is Script {
 
         bytes32 pairA = keccak256(bytes(vm.envString("CURRENCY_PAIR_A")));
         bytes32 pairB = keccak256(bytes(vm.envString("CURRENCY_PAIR_B")));
+
         bytes32[] memory pairs = new bytes32[](2);
         pairs[0] = pairA;
         pairs[1] = pairB;
@@ -31,7 +32,20 @@ contract AstriaOracleScript is Script {
 
         oracle.initializeCurrencyPair(pairA, 18);
         oracle.initializeCurrencyPair(pairB, 18);
-        oracle.updatePriceData(pairs, prices);
+        oracle.setPrices(pairs, prices);
+
+        vm.stopBroadcast();
+    }
+
+    function setPrice() public {
+        address oracleContract = vm.envAddress("ORACLE_CONTRACT_ADDRESS");
+        AstriaOracle oracle = AstriaOracle(oracleContract);
+
+        vm.startBroadcast(vm.envUint("EVM_ORACLE_SENDER_ADDRESS_PRIVATE_KEY"));
+
+        bytes32 pair = keccak256(bytes(vm.envString("CURRENCY_PAIR_A")));
+        uint128 price = uint128(400000000000000);
+        oracle.setPrice(pair, price);
 
         vm.stopBroadcast();
     }

--- a/script/AstriaOracle.s.sol
+++ b/script/AstriaOracle.s.sol
@@ -30,8 +30,8 @@ contract AstriaOracleScript is Script {
         prices[0] = uint128(400000000000000);
         prices[1] = uint128(500000000000000);
 
-        oracle.initializeCurrencyPair(pairA, 18);
-        oracle.initializeCurrencyPair(pairB, 18);
+        oracle.setCurrencyPair(pairA, 18);
+        oracle.setCurrencyPair(pairB, 18);
         oracle.setPrices(pairs, prices);
 
         vm.stopBroadcast();

--- a/src/AstriaOracle.sol
+++ b/src/AstriaOracle.sol
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.21;
 
+import {Ownable} from "../lib/Ownable.sol";
+
 // Core oracle contract for Astria's native oracle.
 // This contract stores the price data for every currency pair supported by the oracle.
-contract AstriaOracle {
+contract AstriaOracle is Ownable {
     // the `astriaOracleCallerAddress` built into the astria-geth node
     address public immutable ORACLE;
+
+    // whether currency pair authorization is required to initialize a currency pair
+    // only the owner can set this value
+    bool public requireCurrencyPairAuthorization;
+
+    // mapping of hash of the currency pair string to whether it is authorized
+    // only used if `requireCurrencyPairAuthorization` is true
+    mapping(bytes32 => bool) public authorizedCurrencyPairs;
 
     struct CurrencyPairInfo {
         // require an explicit initialization boolean, as otherwise the default value of 0 would be ambiguous
@@ -36,21 +46,37 @@ contract AstriaOracle {
     // occurs when attempting to update the price for an uninitialized currency pair
     error UninitializedCurrencyPair(uint256 index);
 
+    // occurs when attempting to initialize an unauthorized currency pair, when authorization is required
+    error UnauthorizedCurrencyPair(bytes32 currencyPair);
+
     modifier onlyOracle() {
         require(msg.sender == ORACLE, "AstriaOracle: only oracle can update");
         _;
     }
 
-    constructor(address _oracle) {
+    constructor(address _oracle, bool _requireCurrencyPairAuthorization) Ownable(msg.sender) {
         ORACLE = _oracle;
+        requireCurrencyPairAuthorization = _requireCurrencyPairAuthorization;
+    }
+
+    function setRequireCurrencyPairAuthorization(bool _requireCurrencyPairAuthorization) external onlyOwner {
+        requireCurrencyPairAuthorization = _requireCurrencyPairAuthorization;
+    }
+
+    function authorizeCurrencyPair(bytes32 _currencyPair) external onlyOwner {
+        authorizedCurrencyPairs[_currencyPair] = true;
     }
 
     function initializeCurrencyPair(bytes32 _currencyPair, uint8 _decimals) external onlyOracle {
+        if (requireCurrencyPairAuthorization && !authorizedCurrencyPairs[_currencyPair]) {
+            revert UnauthorizedCurrencyPair(_currencyPair);
+        }
+
         currencyPairInfo[_currencyPair] = CurrencyPairInfo(true, _decimals);
         emit CurrencyPairInitialized(_currencyPair, _decimals);
     }
 
-    function updatePriceData(bytes32[] memory _currencyPairs, uint128[] memory _prices) external onlyOracle {
+    function setPrices(bytes32[] memory _currencyPairs, uint128[] memory _prices) external onlyOracle {
         require(_currencyPairs.length == _prices.length, "currency pair and price length mismatch");
         latestBlockNumber = block.number;
 
@@ -62,5 +88,16 @@ contract AstriaOracle {
             priceData[latestBlockNumber][_currencyPairs[i]] = PriceData(_prices[i], block.timestamp);
             emit PriceDataUpdated(_currencyPairs[i], _prices[i]);
         }
+    }
+
+    function setPrice(bytes32 _currencyPair, uint128 _price) external onlyOracle {
+        latestBlockNumber = block.number;
+
+        if (!currencyPairInfo[_currencyPair].initialized) {
+            revert UninitializedCurrencyPair(0);
+        }
+
+        priceData[latestBlockNumber][_currencyPair] = PriceData(_price, block.timestamp);
+        emit PriceDataUpdated(_currencyPair, _price);
     }
 }

--- a/src/AstriaOracle.sol
+++ b/src/AstriaOracle.sol
@@ -37,8 +37,8 @@ contract AstriaOracle is Ownable {
     // block number of the latest price data update
     uint256 public latestBlockNumber;
 
-    // occurs when a currency pair is initialized
-    event CurrencyPairInitialized(bytes32 currencyPair, uint8 decimals);
+    // occurs when a currency pair is set
+    event CurrencyPairSet(bytes32 currencyPair, uint8 decimals);
 
     // occurs when a pair's price data is updated
     event PriceDataUpdated(bytes32 currencyPair, uint128 price);
@@ -46,7 +46,7 @@ contract AstriaOracle is Ownable {
     // occurs when attempting to update the price for an uninitialized currency pair
     error UninitializedCurrencyPair(uint256 index);
 
-    // occurs when attempting to initialize an unauthorized currency pair, when authorization is required
+    // occurs when attempting to set an unauthorized currency pair, when authorization is required
     error UnauthorizedCurrencyPair(bytes32 currencyPair);
 
     modifier onlyOracle() {
@@ -67,7 +67,7 @@ contract AstriaOracle is Ownable {
         authorizedCurrencyPairs[_currencyPair] = true;
     }
 
-    function initializeCurrencyPair(bytes32 _currencyPair, uint8 _decimals) external onlyOracle {
+    function setCurrencyPair(bytes32 _currencyPair, uint8 _decimals) external onlyOracle {
         if (
             requireCurrencyPairAuthorization && !authorizedCurrencyPairs[_currencyPair]
                 && !currencyPairInfo[_currencyPair].initialized
@@ -76,7 +76,7 @@ contract AstriaOracle is Ownable {
         }
 
         currencyPairInfo[_currencyPair] = CurrencyPairInfo(true, _decimals);
-        emit CurrencyPairInitialized(_currencyPair, _decimals);
+        emit CurrencyPairSet(_currencyPair, _decimals);
     }
 
     function setPrices(bytes32[] memory _currencyPairs, uint128[] memory _prices) external onlyOracle {

--- a/src/AstriaOracle.sol
+++ b/src/AstriaOracle.sol
@@ -68,7 +68,10 @@ contract AstriaOracle is Ownable {
     }
 
     function initializeCurrencyPair(bytes32 _currencyPair, uint8 _decimals) external onlyOracle {
-        if (requireCurrencyPairAuthorization && !authorizedCurrencyPairs[_currencyPair]) {
+        if (
+            requireCurrencyPairAuthorization && !authorizedCurrencyPairs[_currencyPair]
+                && !currencyPairInfo[_currencyPair].initialized
+        ) {
             revert UnauthorizedCurrencyPair(_currencyPair);
         }
 

--- a/test/AstriaOracle.t.sol
+++ b/test/AstriaOracle.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {AstriaOracle} from "../src/AstriaOracle.sol";
+
+contract AstriaOracleTest is Test {
+    AstriaOracle public oracle;
+    address public oracleCallerAddress = 0x0000000000000000000000000000000000000089;
+    address public owner;
+
+    function setUp() public {
+        owner = msg.sender;
+        oracle = new AstriaOracle(oracleCallerAddress, false);
+    }
+
+    function test_initializeCurrencyPair_noAuthorizationNeeded() public {
+        vm.prank(oracleCallerAddress);
+
+        bytes32 pair = keccak256(bytes("ETH/USD"));
+        oracle.initializeCurrencyPair(pair, 18);
+        (bool initialized, uint8 decimals) = oracle.currencyPairInfo(pair);
+        assert(initialized);
+        assertEq(decimals, 18, "decimals should be 18");
+    }
+
+    function test_initializeCurrencyPair_authorizationNeeded() public {
+        bytes32 pair = keccak256(bytes("ETH/USD"));
+        oracle.setRequireCurrencyPairAuthorization(true);
+        vm.expectRevert();
+        vm.prank(oracleCallerAddress);
+        oracle.initializeCurrencyPair(pair, 18);
+
+        oracle.authorizeCurrencyPair(pair);
+        vm.prank(oracleCallerAddress);
+        oracle.initializeCurrencyPair(pair, 18);
+        (bool initialized, uint8 decimals) = oracle.currencyPairInfo(pair);
+        assert(initialized);
+        assertEq(decimals, 18, "decimals should be 18");
+    }
+}

--- a/test/AstriaOracle.t.sol
+++ b/test/AstriaOracle.t.sol
@@ -18,7 +18,7 @@ contract AstriaOracleTest is Test {
         vm.prank(oracleCallerAddress);
 
         bytes32 pair = keccak256(bytes("ETH/USD"));
-        oracle.initializeCurrencyPair(pair, 18);
+        oracle.setCurrencyPair(pair, 18);
         (bool initialized, uint8 decimals) = oracle.currencyPairInfo(pair);
         assert(initialized);
         assertEq(decimals, 18, "decimals should be 18");
@@ -29,11 +29,11 @@ contract AstriaOracleTest is Test {
         oracle.setRequireCurrencyPairAuthorization(true);
         vm.expectRevert();
         vm.prank(oracleCallerAddress);
-        oracle.initializeCurrencyPair(pair, 18);
+        oracle.setCurrencyPair(pair, 18);
 
         oracle.authorizeCurrencyPair(pair);
         vm.prank(oracleCallerAddress);
-        oracle.initializeCurrencyPair(pair, 18);
+        oracle.setCurrencyPair(pair, 18);
         (bool initialized, uint8 decimals) = oracle.currencyPairInfo(pair);
         assert(initialized);
         assertEq(decimals, 18, "decimals should be 18");


### PR DESCRIPTION
- changes `AstriaOracle` to be ownable
- allow to owner to toggle whether pairs need to be authorized or not before being initialized, and allows it to authorize pairs as well
- since the rollup tries to auto-initialize all pairs it receives from the sequencer (if not initialized), this prevents the rollup from initializing and storing prices for pairs that are not authorized, if thus desired
- if `requireCurrencyPairAuthorization` is false, the contract/rollup behave the same as previously